### PR TITLE
Add user group allow list to config

### DIFF
--- a/jupyterhub_config.py
+++ b/jupyterhub_config.py
@@ -65,6 +65,8 @@ c.JupyterHub.services = [
             f"http://{c.JupyterHub.hub_ip}:{c.JupyterHub.port}",
             "--update_exporter_interval",
             f"{jupyterhub_groups_exporter_interval}",
+            # "--groups_allowed",
+            # "group-0", "group-1",
             "--log_level",
             f"{log_level}",
         ],


### PR DESCRIPTION
PromQL can only support many-to-one/one-to-many table joins. For some hubs, a user may be a member of more than one user group, which violates this. 

This PR introduces a config to allow a list of user groups for the exporter to help preserve a one-to-one relationship between users and groups.

Ref: https://github.com/2i2c-org/infrastructure/issues/5825