### PR TITLE
Add namespace to metric

### DIFF
--- a/helm/jupyterhub-groups-exporter/templates/deployment.yaml
+++ b/helm/jupyterhub-groups-exporter/templates/deployment.yaml
@@ -41,6 +41,8 @@ spec:
             {{- with .Values.extraEnv }}
             {{- tpl (. | toYaml) $ | nindent 12 }}
             {{- end }}
+            - name: NAMESPACE
+              value: {{ .Release.Name }}            
           ports:
             - name: http
               containerPort: {{ .Values.service.port }}


### PR DESCRIPTION
The metric `jupyterhub_user_group_info` should account for different membership models across multi-hub deployments, therefore we need to add the hub namespace to this metric so that we can also filter by hub.

Ref https://github.com/2i2c-org/infrastructure/issues/5805