### PR TITLE
Add escaped username

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "asyncio>=3.4.0",
     "backoff>=2.2.0",
     "prometheus_client>=0.21.0",
+    "git+https://github.com/minrk/escapism.git>=1.1.0.dev0"
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "asyncio>=3.4.0",
     "backoff>=2.2.0",
     "prometheus_client>=0.21.0",
-    "git+https://github.com/minrk/escapism.git>=1.1.0.dev0"
+    "escapism@git+https://github.com/minrk/escapism.git",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Keep track of an escaped username to use when a 'safe' string is required, e.g. kubernetes pod labels, directory names, etc.