### PR TITLE
Remove subpath

### DIFF
--- a/jupyterhub_groups_exporter/groups_exporter.py
+++ b/jupyterhub_groups_exporter/groups_exporter.py
@@ -188,7 +188,7 @@ def sub_app(
     app["update_interval"] = update_interval
     app["USER_GROUP"] = USER_GROUP
     app.router.add_get("/", handle_home)
-    app.router.add_get("/metrics/user-groups", handle_groups)
+    app.router.add_get("/metrics", handle_groups)
     app.on_startup.append(on_startup)
     app.on_cleanup.append(on_cleanup)
     return app


### PR DESCRIPTION
TIL Prometheus can only scrape one path per pod 🙃 (unless you wanna set up jobs in the Prometheus [scrape configs](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config), but lets not subject folks to that)

Ref: https://github.com/2i2c-org/infrastructure/issues/6861